### PR TITLE
Change CSS of headings to distinguish them better

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1066,19 +1066,20 @@ h6 .small,
 }
 h1,
 .h1 {
-  font-size: 30px;
+  font-size: 34px;
 }
 h2,
 .h2 {
-  font-size: 26px;
+  font-size: 28px;
+  border-bottom: 1px solid #dddddd;
 }
 h3,
 .h3 {
-  font-size: 24px;
+  font-size: 23px;
 }
 h4,
 .h4 {
-  font-size: 19px;
+  font-size: 18px;
 }
 h5,
 .h5 {


### PR DESCRIPTION
I found it very hard to tell different heading levels apart, especially `h2`s and `h3`s. I have changed their sizes and added a subtle line below `h2`s so that they are more distinguishable, but still readable and not too small.
### Before

![about:jisp before heading style changes](https://cloud.githubusercontent.com/assets/79168/4181208/1417870a-3712-11e4-94f1-ddce2fd4193e.png)
### After

![about:jisp after heading style changes](https://cloud.githubusercontent.com/assets/79168/4181209/1bf899dc-3712-11e4-9729-fa6508136d9a.png)
